### PR TITLE
Fix: set full page background color to yellow

### DIFF
--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -1,3 +1,6 @@
+html {
+  background-color: yellow;
+}
 * {
   box-sizing: border-box;
   margin: 0;
@@ -12,7 +15,7 @@ body {
   max-width: 1200px;
   margin: 0 auto;
   padding: 20px;
-  background-color: #f5f5f5;
+  background-color: yellow;
 }
 
 header {


### PR DESCRIPTION
This PR fixes the bug where the page background was white instead of yellow. The background color is now set to yellow for both the html and body elements, ensuring the entire viewport is covered as intended.